### PR TITLE
Add usage example on replit to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ chat amongst clients.
 - Run `python client.py`.
 - You can then start chatting amongst clients.
 
-**Here is a use example at replit**
+**Here is a use example at replit:**
+
 If you don´t want to install it, you can test it at replit, like this:
+
 ![img.png](img.png)
 this is the link:
 https://replit.com/@Tihamer-k/Client-Server-Py


### PR DESCRIPTION
In an effort to provide a more user-friendly and accessible experience, an example usage on the platform 'replit' was added to the README file. By using this online platform, users who don't want to install the software can test it directly. An image and link to the replit were included. Accompanying explanations were updated accordingly to facilitate better understanding.